### PR TITLE
quick fix to support PC 2024.1

### DIFF
--- a/vg.go
+++ b/vg.go
@@ -40,7 +40,7 @@ func GetVGList() {
 		} `json:"data"`
 	}
 
-	MyPrism.CallAPIJSON("PC", "GET", "/api/storage/v4.0.a2/config/storage-containers", "", &tmp1)
+	MyPrism.CallAPIJSON("PC", "GET", "/api/clustermgmt/v4.0.b2/config/storage-containers", "", &tmp1)
 
 	// Parse all SC
 	for tmp := range tmp1.Data {


### PR DESCRIPTION
quick fix to restore PC 2024.1 compatibility

move removed alpha storage-container API call to support beta one

break compatibility with older PC

TODO

All other call APIs would also have to be upgraded from alpha to beta versions.